### PR TITLE
upd comment to use kirkstone migrated env var

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -15,7 +15,7 @@ LAYERSERIES_COMPAT_azure-device-update  = "honister kirkstone"
 
 # Layer-specific configuration variables.
 # These values can/will be overriden by environment variables
-# if those variables are added to the BB_ENV_EXTRAWHITE environment variable.
+# if those variables are added to the BB_ENV_PASSTHROUGH_ADDITIONS environment variable.
 
 # ADU_SOFTWARE_VERSION will be written to a file that is read by the ADU Client.
 # This value will be reported through the Device Information PnP interface by the ADU Client


### PR DESCRIPTION
update comment in conf/layer.conf as kirkstone uses BB_ENV_PASSTHROUGH_ADDITIONS instead of BB_ENV_EXTRAWHITE 